### PR TITLE
Fix the tox CI run (linting)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,7 @@ jobs=2
 [MESSAGES CONTROL]
 
 # Ignore keyword argument 'registry'
-disable = E1123,no-member,len-as-condition
+disable = E1123,no-member,len-as-condition,duplicate-code
 
 
 [REPORTS]

--- a/metrics/helpers/sstreams.py
+++ b/metrics/helpers/sstreams.py
@@ -235,4 +235,4 @@ class NotFilter(MultiFilter):
     @staticmethod
     def operation(value):
         """Inverse the filter."""
-        return all([not x for x in value])
+        return all((not x for x in value))


### PR DESCRIPTION
Preparatory work for some more changes to make the metrics jobs more stable.

Changes:
- pylint: ignore duplicate-code (R0801)
- pylint: fix use-a-generator (R1729)
